### PR TITLE
getLanguages is not static

### DIFF
--- a/lib/TextLanguageDetect/TextLanguageDetect.php
+++ b/lib/TextLanguageDetect/TextLanguageDetect.php
@@ -422,7 +422,7 @@ class TextLanguageDetect
      * @return array        the names of the languages known to this object<<<<<<<
      * @throws   TextLanguageDetectException
      */
-    public static function getLanguages()
+    public function getLanguages()
     {
         return $this->_convertToNameMode(
             array_keys($this->_lang_db)


### PR DESCRIPTION
Is not necessary for getLanguages to be static. In PHP 5.6 throw an error like "$this is not accessible in static context", and in the example, TextLanguageDetect is always instantiated.
